### PR TITLE
Correct 10 of clubs

### DIFF
--- a/resources/js/cardImages.js
+++ b/resources/js/cardImages.js
@@ -66,7 +66,7 @@ export const cardImages = {
     '7c': clubs_7,
     '8c': clubs_8,
     '9c': clubs_9,
-    '10c': clubs_10,
+    'Tc': clubs_10,
     'Jc': clubs_J,
     'Qc': clubs_Q,
     'Kc': clubs_K,


### PR DESCRIPTION
The 10 of clubs was previously defined as '10c' instead of using T (Tc) like the other suits, rendering the 10 of clubs unusable as it would throw an error. This PR fixes that!