### PR TITLE
Improve styling

### DIFF
--- a/resources/js/Components/Welcome.css
+++ b/resources/js/Components/Welcome.css
@@ -62,6 +62,12 @@ input:focus {
   box-shadow: 0 0 5px rgba(52, 152, 219, 0.5);
 }
 
+input:read-only {
+  background-color: #f0f0f0;
+  color: #888;
+  cursor: not-allowed;
+}
+
 /* CARDS */
 
 .pokerCards {

--- a/resources/js/Components/Welcome.css
+++ b/resources/js/Components/Welcome.css
@@ -1,20 +1,23 @@
 html, body {
-  margin: 0px;
-  font-family: Calibri, 'Trebuchet MS', sans-serif;
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #f0f0f0;
 }
 
 .containerMain {
   display: flex;
   flex-direction: column;
-  background-color: rgb(215, 215, 215);
+  background-color: #ffffff;
+  margin: 0 auto;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
 }
 
 h1 {
   font-size: 40px;
   font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-  color: rgb(68, 64, 82);
+  color: #2c3e50;
   text-align: center;
-  margin: 20px;
+  margin: 30px 0;
 }
 
 .pokerhandsDisplay {
@@ -34,12 +37,29 @@ input {
   padding: 8px;
   flex: 1 1 200px;
   max-width: 300px;
-  border-radius: 10px;
-  border: none;
+  border-radius: 5px;
+  border: 1px solid #dcdcdc;
+  transition: all 0.3s ease;
+}
+
+button {
+  background-color: #3498db;
+  color: white;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #2980b9;
 }
 
 input {
-  min-width: 135px; /* Ensures that the input placeholder is not cut off */
+  min-width: 135px;
+}
+
+input:focus {
+  outline: none;
+  border-color: #3498db;
+  box-shadow: 0 0 5px rgba(52, 152, 219, 0.5);
 }
 
 /* CARDS */
@@ -47,36 +67,43 @@ input {
 .pokerCards {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 20px;
+  gap: 15px;
+  margin-top: 30px;
   justify-content: center;
 }
 
 .card {
   text-align: center;
   margin: 10px;
-  background-color: rgb(233, 233, 233);
-  padding: 10px 5px 10px 5px;
+  background-color: #f5f5f5;
+  padding: 15px 10px;
   border-radius: 10px;
-  transition: background-color 0.3s ease;
+  transition: all 0.3s ease;
   cursor: pointer;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 .card:hover {
-  background-color: rgb(161, 161, 161);
-  transform: scale(1.05);
-  transition: all 0.3s ease;
+  background-color: #e8e8e8;
+  transform: translateY(-5px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
 }
 
 .card-image {
-  width: 60px;
-  height: 90px;
+  width: 65px;
+  height: auto;
+  object-fit: contain;
+  border-radius: 5px;
+  border: 1px solid #dcdcdc;
+  padding: 0px;
+  margin: 0px;
 }
 
 .card-label {
   width: 90%;
-  margin: 0 auto;
+  margin: 10px auto 0;
   text-align: center;
-  margin-top: 5px;
-  padding: 0px;
+  padding: 0;
+  font-size: 14px;
+  color: #34495e;
 }

--- a/resources/js/Components/Welcome.css
+++ b/resources/js/Components/Welcome.css
@@ -58,8 +58,6 @@ input {
 
 input:focus {
   outline: none;
-  border-color: #3498db;
-  box-shadow: 0 0 5px rgba(52, 152, 219, 0.5);
 }
 
 input:read-only {

--- a/resources/js/Components/Welcome.css
+++ b/resources/js/Components/Welcome.css
@@ -111,3 +111,14 @@ input:read-only {
   font-size: 14px;
   color: #34495e;
 }
+
+.card.selected {
+  background-color: #d4e6f1;
+  border: 1px dashed #3498db;
+  transform: translateY(5px);
+  box-shadow: none;
+}
+
+.card.selected:hover {
+  cursor: not-allowed;
+}

--- a/resources/js/Components/Welcome.css
+++ b/resources/js/Components/Welcome.css
@@ -14,10 +14,10 @@ body {
 }
 
 h1 {
-    font-size: 40px;
+    font-size: 4vw;
     font-family: "Gill Sans", "Gill Sans MT", Calibri, "Trebuchet MS",
         sans-serif;
-    color: #2c3e50;
+    color: #1a5f7a;
     text-align: center;
     margin: 30px 0;
 }
@@ -27,9 +27,9 @@ h1 {
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
-    gap: 10px;
-    max-width: 100%;
-    padding: 10px;
+    gap: 5px;
+    max-width: 95%;
+    margin: 0 auto;
 }
 
 button,
@@ -55,7 +55,7 @@ button:hover {
 }
 
 input {
-    min-width: 135px;
+    min-width: 150px;
 }
 
 input:focus {
@@ -64,7 +64,7 @@ input:focus {
 
 input:read-only {
     background-color: #f0f0f0;
-    color: #888;
+    opacity: 0.7;
     cursor: not-allowed;
 }
 
@@ -75,14 +75,15 @@ input:read-only {
     margin: 30px auto;
     display: flex;
     flex-wrap: wrap;
-    gap: 25px;
+    gap: 20px;
     justify-content: center;
 }
 
 .card {
     text-align: center;
     background-color: #f5f5f5;
-    padding: 15px 10px;
+    padding: 5px 10px;
+    padding-top: 10px;
     border-radius: 10px;
     transition: all 0.3s ease;
     cursor: pointer;
@@ -106,12 +107,12 @@ input:read-only {
 }
 
 .card-label {
-    width: 90%;
-    margin: 10px auto 0;
     text-align: center;
-    padding: 0;
+    margin: auto;
+    padding: 3px;
     font-size: 14px;
-    color: #34495e;
+    color: black;
+    font-weight: 200;
 }
 
 .card.selected {
@@ -128,4 +129,18 @@ input:read-only {
 
 .card.selected .card-label {
     color: #1670ac;
+}
+
+@media screen and (max-width: 768px) {
+    h1 {
+        font-size: 32px;
+    }
+
+    .card-image {
+        width: 60px;
+    }
+
+    .card-label {
+        font-size: 15px;
+    }
 }

--- a/resources/js/Components/Welcome.css
+++ b/resources/js/Components/Welcome.css
@@ -1,16 +1,18 @@
 html, body {
   margin: 0px;
+  font-family: Calibri, 'Trebuchet MS', sans-serif;
 }
 
 .containerMain {
   display: flex;
   flex-direction: column;
-  background-color: antiquewhite;
+  background-color: rgb(215, 215, 215);
 }
 
 h1 {
   font-size: 40px;
-  color: red;
+  font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+  color: rgb(68, 64, 82);
   text-align: center;
   margin: 20px;
 }
@@ -32,6 +34,8 @@ input {
   padding: 8px;
   flex: 1 1 200px;
   max-width: 300px;
+  border-radius: 10px;
+  border: none;
 }
 
 input {
@@ -41,7 +45,6 @@ input {
 /* CARDS */
 
 .pokerCards {
-  padding: 10px;
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
@@ -52,6 +55,17 @@ input {
 .card {
   text-align: center;
   margin: 10px;
+  background-color: rgb(233, 233, 233);
+  padding: 10px 5px 10px 5px;
+  border-radius: 10px;
+  transition: background-color 0.3s ease;
+  cursor: pointer;
+}
+
+.card:hover {
+  background-color: rgb(161, 161, 161);
+  transform: scale(1.05);
+  transition: all 0.3s ease;
 }
 
 .card-image {
@@ -60,5 +74,9 @@ input {
 }
 
 .card-label {
+  width: 90%;
+  margin: 0 auto;
+  text-align: center;
   margin-top: 5px;
+  padding: 0px;
 }

--- a/resources/js/Components/Welcome.css
+++ b/resources/js/Components/Welcome.css
@@ -1,124 +1,131 @@
-html, body {
-  margin: 0;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f0f0f0;
+html,
+body {
+    margin: 0;
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+    background-color: #f0f0f0;
 }
 
 .containerMain {
-  display: flex;
-  flex-direction: column;
-  background-color: #ffffff;
-  margin: 0 auto;
-  box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    background-color: #ffffff;
+    margin: 0 auto;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
 }
 
 h1 {
-  font-size: 40px;
-  font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-  color: #2c3e50;
-  text-align: center;
-  margin: 30px 0;
+    font-size: 40px;
+    font-family: "Gill Sans", "Gill Sans MT", Calibri, "Trebuchet MS",
+        sans-serif;
+    color: #2c3e50;
+    text-align: center;
+    margin: 30px 0;
 }
 
 .pokerhandsDisplay {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-items: center;
-  gap: 10px;
-  max-width: 100%;
-  padding: 10px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    max-width: 100%;
+    padding: 10px;
 }
 
 button,
 input {
-  font-size: 16px;
-  margin: 5px;
-  padding: 8px;
-  flex: 1 1 200px;
-  max-width: 300px;
-  border-radius: 5px;
-  border: 1px solid #dcdcdc;
-  transition: all 0.3s ease;
+    font-size: 16px;
+    margin: 5px;
+    padding: 8px;
+    flex: 1 1 200px;
+    max-width: 300px;
+    border-radius: 5px;
+    border: 1px solid #dcdcdc;
+    transition: all 0.3s ease;
 }
 
 button {
-  background-color: #3498db;
-  color: white;
-  cursor: pointer;
+    background-color: #3498db;
+    color: white;
+    cursor: pointer;
 }
 
 button:hover {
-  background-color: #2980b9;
+    background-color: #2980b9;
 }
 
 input {
-  min-width: 135px;
+    min-width: 135px;
 }
 
 input:focus {
-  outline: none;
+    outline: none;
 }
 
 input:read-only {
-  background-color: #f0f0f0;
-  color: #888;
-  cursor: not-allowed;
+    background-color: #f0f0f0;
+    color: #888;
+    cursor: not-allowed;
 }
 
 /* CARDS */
 
 .pokerCards {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
-  margin-top: 30px;
-  justify-content: center;
+    width: 95%;
+    margin: 30px auto;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 25px;
+    justify-content: center;
 }
 
 .card {
-  text-align: center;
-  margin: 10px;
-  background-color: #f5f5f5;
-  padding: 15px 10px;
-  border-radius: 10px;
-  transition: all 0.3s ease;
-  cursor: pointer;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    text-align: center;
+    background-color: #f5f5f5;
+    padding: 15px 10px;
+    border-radius: 10px;
+    transition: all 0.3s ease;
+    cursor: pointer;
+    box-shadow: 0 3px 5px rgba(0, 0, 0, 0.1);
 }
 
 .card:hover {
-  background-color: #e8e8e8;
-  transform: translateY(-5px);
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+    background-color: #e8e8e8;
+    transform: translateY(-5px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 .card-image {
-  width: 65px;
-  height: auto;
-  object-fit: contain;
-  border-radius: 5px;
-  border: 1px solid #dcdcdc;
-  padding: 0px;
-  margin: 0px;
+    width: 65px;
+    height: auto;
+    object-fit: contain;
+    border-radius: 5px;
+    border: 1px ridge darkgray;
+    padding: 0px;
+    margin: 0px;
 }
 
 .card-label {
-  width: 90%;
-  margin: 10px auto 0;
-  text-align: center;
-  padding: 0;
-  font-size: 14px;
-  color: #34495e;
+    width: 90%;
+    margin: 10px auto 0;
+    text-align: center;
+    padding: 0;
+    font-size: 14px;
+    color: #34495e;
 }
 
 .card.selected {
-  background-color: #d4e6f1;
-  border: 1px dashed #3498db;
-  transform: translateY(5px);
-  box-shadow: none;
+    background-color: #d4e6f1;
+    box-shadow: inset 0 0 0 1px #6dacd6;
+    transform: translateY(5px);
+    opacity: 0.7;
 }
 
 .card.selected:hover {
-  cursor: not-allowed;
+    background-color: #d4e6f1;
+    cursor: not-allowed;
+}
+
+.card.selected .card-label {
+    color: #1670ac;
 }

--- a/resources/js/Components/Welcome.vue
+++ b/resources/js/Components/Welcome.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="containerMain">
-    <h1>Welcome to Lucas Poker Odds Calculator!</h1>
+    <h1>Lucas Poker Odds Calculator</h1>
     <div class="pokerhandsDisplay">
       <!-- Player inputs -->
       <input v-model="player1Hand" placeholder="Player 1 Hand (e.g., Qs Ks)" readonly/>

--- a/resources/js/Components/Welcome.vue
+++ b/resources/js/Components/Welcome.vue
@@ -18,7 +18,13 @@
     </div>
     <div class="pokerCards">
       <!-- Display card images -->
-      <div v-for="(image, card) in cardImages" :key="card" class="card" @click="addCard(card)">
+      <div 
+        v-for="(image, card) in cardImages" 
+        :key="card" 
+        class="card" 
+        :class="{ selected: isCardSelected(card) }"
+        @click="addCard(card)"
+      >
         <img :src="image" :alt="card" class="card-image"/>
         <div class="card-label">{{ formatCardLabel(card) }}</div>
       </div>
@@ -135,6 +141,11 @@ export default {
       this.selectedPlayer1Cards = [];
       this.selectedPlayer2Cards = [];
       this.selectedBoardCards = [];
+    },
+    isCardSelected(card) {
+      return this.selectedPlayer1Cards.includes(card) ||
+             this.selectedPlayer2Cards.includes(card) ||
+             this.selectedBoardCards.includes(card);
     }
   }
 };

--- a/resources/js/Components/Welcome.vue
+++ b/resources/js/Components/Welcome.vue
@@ -18,8 +18,8 @@
     </div>
     <div class="pokerCards">
       <!-- Display card images -->
-      <div v-for="(image, card) in cardImages" :key="card" class="card">
-        <img :src="image" :alt="card" class="card-image" @click="addCard(card)" />
+      <div v-for="(image, card) in cardImages" :key="card" class="card" @click="addCard(card)">
+        <img :src="image" :alt="card" class="card-image"/>
         <div class="card-label">{{ formatCardLabel(card) }}</div>
       </div>
     </div>


### PR DESCRIPTION
Closes #1 

This PR makes these visual improvements:
- Theme has been changed to white & blue
- Cards are now held in their own clickable divs, animate for hovering, clicking, and selected, and now show the cursor as not allowed if the card is already in use
- Buttons now separate from inputs when possible
- Adjusted title, fonts, etc

## Mobile View

Before | After
:-------------------------:|:-------------------------:
![beforemobile](https://github.com/user-attachments/assets/607d3fcd-49a2-4f30-9507-b7c7af33c335) | ![aftermobile](https://github.com/user-attachments/assets/e786c66d-4aa3-4444-a27b-de799515d249)

## Desktop View

Before | After
:-------------------------:|:-------------------------:
![beforedesktop](https://github.com/user-attachments/assets/4d4c3bf8-e580-44f5-8496-2ca282d7782c) | ![afterdesktop](https://github.com/user-attachments/assets/aaf5f26a-06e1-4908-b33b-57169d34f27e)